### PR TITLE
Use official Elasticsearch image as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM elasticsearch:5.6.6
+FROM docker.elastic.co/elasticsearch/elasticsearch:5.6.6
 
-RUN bin/elasticsearch-plugin install ingest-attachment
+RUN bin/elasticsearch-plugin install -s -b ingest-attachment

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # elasticsearch-ingest-attachment
 
-docker with elasticsearch 5.1.2 and ingest-attachment plugin 
+Docker image with Elasticsearch 5.6.6 and ingest-attachment plugin
+
+Image is hosted at
+[veelo/elasticsearch-ingest-attachment](https://hub.docker.com/r/veelo/elasticsearch-ingest-attachment/).


### PR DESCRIPTION
According to <https://hub.docker.com/_/elasticsearch/>, the `elasticsearch` images at Docker Hub are deprecated. We should use the official images from <https://www.docker.elastic.co> instead.